### PR TITLE
Add localized translations throughout the app

### DIFF
--- a/Yes-You-Can-Front/src/components/ExampleComponent.vue
+++ b/Yes-You-Can-Front/src/components/ExampleComponent.vue
@@ -6,14 +6,23 @@
         {{ todo.id }} - {{ todo.content }}
       </li>
     </ul>
-    <p>Count: {{ todoCount }} / {{ meta.totalCount }}</p>
-    <p>Active: {{ active ? 'yes' : 'no' }}</p>
-    <p>Clicks on todos: {{ clickCount }}</p>
+    <p>
+      {{ t('components.example.todoCount', { done: todoCount, total: meta.totalCount }) }}
+    </p>
+    <p>
+      {{
+        t('components.example.active', {
+          status: active ? t('common.boolean.yes') : t('common.boolean.no'),
+        })
+      }}
+    </p>
+    <p>{{ t('components.example.clickCount', { count: clickCount }) }}</p>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 import type { Todo, Meta } from './models';
 
 interface Props {
@@ -26,6 +35,8 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), {
   todos: () => [],
 });
+
+const { t } = useI18n();
 
 const clickCount = ref(0);
 function increment() {

--- a/Yes-You-Can-Front/src/i18n/ca-ES/index.ts
+++ b/Yes-You-Can-Front/src/i18n/ca-ES/index.ts
@@ -4,4 +4,75 @@
 export default {
   failed: 'Acció fallida',
   success: "L'acció s'ha realitzat amb èxit",
+  common: {
+    boolean: {
+      yes: 'Sí',
+      no: 'No',
+    },
+  },
+  layout: {
+    header: {
+      menu: 'Menú',
+      title: 'Aplicació Quasar',
+      version: 'Quasar v{version}',
+    },
+    drawer: {
+      essentialLinks: 'Enllaços essencials',
+    },
+    links: {
+      docs: {
+        title: 'Documentació',
+        caption: 'quasar.dev',
+      },
+      github: {
+        title: 'GitHub',
+        caption: 'github.com/quasarframework',
+      },
+      discord: {
+        title: 'Canal de xat a Discord',
+        caption: 'chat.quasar.dev',
+      },
+      forum: {
+        title: 'Fòrum',
+        caption: 'forum.quasar.dev',
+      },
+      twitter: {
+        title: 'Twitter',
+        caption: '@quasarframework',
+      },
+      facebook: {
+        title: 'Facebook',
+        caption: '@QuasarFramework',
+      },
+      awesome: {
+        title: 'Quasar Awesome',
+        caption: 'Projectes de la comunitat Quasar',
+      },
+    },
+  },
+  components: {
+    example: {
+      todoCount: 'Elements: {done} / {total}',
+      active: 'Actiu: {status}',
+      clickCount: 'Clics a les tasques: {count}',
+    },
+  },
+  pages: {
+    index: {
+      example: {
+        title: "Component d'exemple",
+      },
+      todos: {
+        first: 'Millora les teves habilitats amb Quasar',
+        second: 'Explora les funcions de Vue 3',
+        third: 'Comença a construir la teva aplicació',
+        fourth: "Comparteix el progrés amb l'equip",
+        fifth: "Publica i celebra l'èxit",
+      },
+    },
+    error: {
+      description: 'Vaja. Aquí no hi ha res...',
+      goHome: "Torna a l'inici",
+    },
+  },
 };

--- a/Yes-You-Can-Front/src/i18n/en-US/index.ts
+++ b/Yes-You-Can-Front/src/i18n/en-US/index.ts
@@ -4,4 +4,75 @@
 export default {
   failed: 'Action failed',
   success: 'Action was successful',
+  common: {
+    boolean: {
+      yes: 'Yes',
+      no: 'No',
+    },
+  },
+  layout: {
+    header: {
+      menu: 'Menu',
+      title: 'Quasar App',
+      version: 'Quasar v{version}',
+    },
+    drawer: {
+      essentialLinks: 'Essential Links',
+    },
+    links: {
+      docs: {
+        title: 'Docs',
+        caption: 'quasar.dev',
+      },
+      github: {
+        title: 'GitHub',
+        caption: 'github.com/quasarframework',
+      },
+      discord: {
+        title: 'Discord Chat Channel',
+        caption: 'chat.quasar.dev',
+      },
+      forum: {
+        title: 'Forum',
+        caption: 'forum.quasar.dev',
+      },
+      twitter: {
+        title: 'Twitter',
+        caption: '@quasarframework',
+      },
+      facebook: {
+        title: 'Facebook',
+        caption: '@QuasarFramework',
+      },
+      awesome: {
+        title: 'Quasar Awesome',
+        caption: 'Community Quasar projects',
+      },
+    },
+  },
+  components: {
+    example: {
+      todoCount: 'Count: {done} / {total}',
+      active: 'Active: {status}',
+      clickCount: 'Clicks on todos: {count}',
+    },
+  },
+  pages: {
+    index: {
+      example: {
+        title: 'Example component',
+      },
+      todos: {
+        first: 'Improve your Quasar skills',
+        second: 'Explore Vue 3 features',
+        third: 'Start building your app',
+        fourth: 'Share progress with the team',
+        fifth: 'Deploy and celebrate success',
+      },
+    },
+    error: {
+      description: 'Oops. Nothing here...',
+      goHome: 'Go Home',
+    },
+  },
 };

--- a/Yes-You-Can-Front/src/i18n/es-ES/index.ts
+++ b/Yes-You-Can-Front/src/i18n/es-ES/index.ts
@@ -4,4 +4,75 @@
 export default {
   failed: 'Acción fallida',
   success: 'La acción se realizó con éxito',
+  common: {
+    boolean: {
+      yes: 'Sí',
+      no: 'No',
+    },
+  },
+  layout: {
+    header: {
+      menu: 'Menú',
+      title: 'Aplicación Quasar',
+      version: 'Quasar v{version}',
+    },
+    drawer: {
+      essentialLinks: 'Enlaces esenciales',
+    },
+    links: {
+      docs: {
+        title: 'Documentación',
+        caption: 'quasar.dev',
+      },
+      github: {
+        title: 'GitHub',
+        caption: 'github.com/quasarframework',
+      },
+      discord: {
+        title: 'Canal de chat en Discord',
+        caption: 'chat.quasar.dev',
+      },
+      forum: {
+        title: 'Foro',
+        caption: 'forum.quasar.dev',
+      },
+      twitter: {
+        title: 'Twitter',
+        caption: '@quasarframework',
+      },
+      facebook: {
+        title: 'Facebook',
+        caption: '@QuasarFramework',
+      },
+      awesome: {
+        title: 'Quasar Awesome',
+        caption: 'Proyectos de la comunidad de Quasar',
+      },
+    },
+  },
+  components: {
+    example: {
+      todoCount: 'Elementos: {done} / {total}',
+      active: 'Activo: {status}',
+      clickCount: 'Clics en tareas: {count}',
+    },
+  },
+  pages: {
+    index: {
+      example: {
+        title: 'Componente de ejemplo',
+      },
+      todos: {
+        first: 'Mejora tus habilidades con Quasar',
+        second: 'Explora las funciones de Vue 3',
+        third: 'Comienza a construir tu aplicación',
+        fourth: 'Comparte el progreso con el equipo',
+        fifth: 'Implementa y celebra el éxito',
+      },
+    },
+    error: {
+      description: 'Ups. Nada por aquí...',
+      goHome: 'Volver al inicio',
+    },
+  },
 };

--- a/Yes-You-Can-Front/src/layouts/MainLayout.vue
+++ b/Yes-You-Can-Front/src/layouts/MainLayout.vue
@@ -2,19 +2,33 @@
   <q-layout view="lHh Lpr lFf">
     <q-header elevated>
       <q-toolbar>
-        <q-btn flat dense round icon="menu" aria-label="Menu" @click="toggleLeftDrawer" />
+        <q-btn
+          flat
+          dense
+          round
+          icon="menu"
+          :aria-label="t('layout.header.menu')"
+          @click="toggleLeftDrawer"
+        />
 
-        <q-toolbar-title> Quasar App </q-toolbar-title>
+        <q-toolbar-title>{{ t('layout.header.title') }}</q-toolbar-title>
 
-        <div>Quasar v{{ $q.version }}</div>
+        <div>{{ t('layout.header.version', { version: $q.version }) }}</div>
       </q-toolbar>
     </q-header>
 
     <q-drawer v-model="leftDrawerOpen" show-if-above bordered>
       <q-list>
-        <q-item-label header> Essential Links </q-item-label>
+        <q-item-label header>{{ t('layout.drawer.essentialLinks') }}</q-item-label>
 
-        <EssentialLink v-for="link in linksList" :key="link.title" v-bind="link" />
+        <EssentialLink
+          v-for="link in linksList"
+          :key="link.link"
+          :title="link.title"
+          :caption="link.caption"
+          :icon="link.icon"
+          :link="link.link"
+        />
       </q-list>
     </q-drawer>
 
@@ -25,53 +39,69 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 import EssentialLink, { type EssentialLinkProps } from 'components/EssentialLink.vue';
 
-const linksList: EssentialLinkProps[] = [
+const { t } = useI18n();
+
+type LinkDefinition = Pick<EssentialLinkProps, 'icon' | 'link'> & {
+  titleKey: string;
+  captionKey?: string;
+};
+
+const linkDefinitions: LinkDefinition[] = [
   {
-    title: 'Docs',
-    caption: 'quasar.dev',
+    titleKey: 'layout.links.docs.title',
+    captionKey: 'layout.links.docs.caption',
     icon: 'school',
     link: 'https://quasar.dev',
   },
   {
-    title: 'Github',
-    caption: 'github.com/quasarframework',
+    titleKey: 'layout.links.github.title',
+    captionKey: 'layout.links.github.caption',
     icon: 'code',
     link: 'https://github.com/quasarframework',
   },
   {
-    title: 'Discord Chat Channel',
-    caption: 'chat.quasar.dev',
+    titleKey: 'layout.links.discord.title',
+    captionKey: 'layout.links.discord.caption',
     icon: 'chat',
     link: 'https://chat.quasar.dev',
   },
   {
-    title: 'Forum',
-    caption: 'forum.quasar.dev',
+    titleKey: 'layout.links.forum.title',
+    captionKey: 'layout.links.forum.caption',
     icon: 'record_voice_over',
     link: 'https://forum.quasar.dev',
   },
   {
-    title: 'Twitter',
-    caption: '@quasarframework',
+    titleKey: 'layout.links.twitter.title',
+    captionKey: 'layout.links.twitter.caption',
     icon: 'rss_feed',
     link: 'https://twitter.quasar.dev',
   },
   {
-    title: 'Facebook',
-    caption: '@QuasarFramework',
+    titleKey: 'layout.links.facebook.title',
+    captionKey: 'layout.links.facebook.caption',
     icon: 'public',
     link: 'https://facebook.quasar.dev',
   },
   {
-    title: 'Quasar Awesome',
-    caption: 'Community Quasar projects',
+    titleKey: 'layout.links.awesome.title',
+    captionKey: 'layout.links.awesome.caption',
     icon: 'favorite',
     link: 'https://awesome.quasar.dev',
   },
 ];
+
+const linksList = computed<EssentialLinkProps[]>(() =>
+  linkDefinitions.map(({ titleKey, captionKey, ...link }) => ({
+    ...link,
+    title: t(titleKey),
+    caption: captionKey ? t(captionKey) : '',
+  })),
+);
 
 const leftDrawerOpen = ref(false);
 

--- a/Yes-You-Can-Front/src/pages/ErrorNotFound.vue
+++ b/Yes-You-Can-Front/src/pages/ErrorNotFound.vue
@@ -3,7 +3,7 @@
     <div>
       <div style="font-size: 30vh">404</div>
 
-      <div class="text-h2" style="opacity: 0.4">Oops. Nothing here...</div>
+      <div class="text-h2" style="opacity: 0.4">{{ t('pages.error.description') }}</div>
 
       <q-btn
         class="q-mt-xl"
@@ -11,7 +11,7 @@
         text-color="blue"
         unelevated
         to="/"
-        label="Go Home"
+        :label="t('pages.error.goHome')"
         no-caps
       />
     </div>
@@ -19,5 +19,7 @@
 </template>
 
 <script setup lang="ts">
-//
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
 </script>

--- a/Yes-You-Can-Front/src/pages/IndexPage.vue
+++ b/Yes-You-Can-Front/src/pages/IndexPage.vue
@@ -1,7 +1,7 @@
 <template>
   <q-page class="row items-center justify-evenly">
     <example-component
-      title="Example component"
+      :title="exampleTitle"
       active
       :todos="todos"
       :meta="meta"
@@ -10,34 +10,39 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 import type { Todo, Meta } from 'components/models';
 import ExampleComponent from 'components/ExampleComponent.vue';
 
-const todos = ref<Todo[]>([
+const { t } = useI18n();
+
+const todos = computed<Todo[]>(() => [
   {
     id: 1,
-    content: 'ct1',
+    content: t('pages.index.todos.first'),
   },
   {
     id: 2,
-    content: 'ct2',
+    content: t('pages.index.todos.second'),
   },
   {
     id: 3,
-    content: 'ct3',
+    content: t('pages.index.todos.third'),
   },
   {
     id: 4,
-    content: 'ct4',
+    content: t('pages.index.todos.fourth'),
   },
   {
     id: 5,
-    content: 'ct5',
+    content: t('pages.index.todos.fifth'),
   },
 ]);
 
 const meta = ref<Meta>({
   totalCount: 1200,
 });
+
+const exampleTitle = computed(() => t('pages.index.example.title'));
 </script>


### PR DESCRIPTION
## Summary
- integrate vue-i18n lookups into the main layout, index page, and example component
- expand the English, Spanish, and Catalan locale files with complete application strings
- localize the 404 page so navigation text switches with the active language

## Testing
- npm run lint *(fails: missing @eslint/js because the registry request returns 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ca90e404048326bb81dd75db4de214